### PR TITLE
Copy aon regmaps to control to match new dts

### DIFF
--- a/regmaps/sifive_aon0_control.svd
+++ b/regmaps/sifive_aon0_control.svd
@@ -1,0 +1,418 @@
+<registers>
+  <register>
+    <name>backup_0</name>
+    <description>Backup Register 0</description>
+    <addressOffset>0x80</addressOffset>
+  </register>
+  <register>
+    <name>backup_1</name>
+    <description>Backup Register 1</description>
+    <addressOffset>0x84</addressOffset>
+  </register>
+  <register>
+    <name>backup_2</name>
+    <description>Backup Register 2</description>
+    <addressOffset>0x88</addressOffset>
+  </register>
+  <register>
+    <name>backup_3</name>
+    <description>Backup Register 3</description>
+    <addressOffset>0x8C</addressOffset>
+  </register>
+  <register>
+    <name>backup_4</name>
+    <description>Backup Register 4</description>
+    <addressOffset>0x90</addressOffset>
+  </register>
+  <register>
+    <name>backup_5</name>
+    <description>Backup Register 5</description>
+    <addressOffset>0x94</addressOffset>
+  </register>
+  <register>
+    <name>backup_6</name>
+    <description>Backup Register 6</description>
+    <addressOffset>0x98</addressOffset>
+  </register>
+  <register>
+    <name>backup_7</name>
+    <description>Backup Register 7</description>
+    <addressOffset>0x9C</addressOffset>
+  </register>
+  <register>
+    <name>backup_8</name>
+    <description>Backup Register 8</description>
+    <addressOffset>0xA0</addressOffset>
+  </register>
+  <register>
+    <name>backup_9</name>
+    <description>Backup Register 9</description>
+    <addressOffset>0xA4</addressOffset>
+  </register>
+  <register>
+    <name>backup_10</name>
+    <description>Backup Register 10</description>
+    <addressOffset>0xA8</addressOffset>
+  </register>
+  <register>
+    <name>backup_11</name>
+    <description>Backup Register 11</description>
+    <addressOffset>0xAC</addressOffset>
+  </register>
+  <register>
+    <name>backup_12</name>
+    <description>Backup Register 12</description>
+    <addressOffset>0xB0</addressOffset>
+  </register>
+  <register>
+    <name>backup_13</name>
+    <description>Backup Register 13</description>
+    <addressOffset>0xB4</addressOffset>
+  </register>
+  <register>
+    <name>backup_14</name>
+    <description>Backup Register 14</description>
+    <addressOffset>0xB8</addressOffset>
+  </register>
+  <register>
+    <name>backup_15</name>
+    <description>Backup Register 15</description>
+    <addressOffset>0xBC</addressOffset>
+  </register>
+  <register>
+    <name>wdogcfg</name>
+    <description>wdog Configuration</description>
+    <addressOffset>0x0</addressOffset>
+    <fields>
+      <field>
+        <name>wdogscale</name>
+        <description>Counter scale value.</description>
+        <bitRange>[3:0]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogrsten</name>
+        <description>Controls whether the comparator output can set the wdogrst bit and hence cause a full reset.</description>
+        <bitRange>[8:8]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogzerocmp</name>
+        <description>Reset counter to zero after match.</description>
+        <bitRange>[9:9]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogenalways</name>
+        <description>Enable Always - run continuously</description>
+        <bitRange>[12:12]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogcoreawake</name>
+        <description>Increment the watchdog counter if the processor is not asleep</description>
+        <bitRange>[13:13]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogip0</name>
+        <description>Interrupt 0 Pending</description>
+        <bitRange>[28:28]</bitRange>
+        <access>read-write</access>
+      </field>
+    </fields>
+  </register>
+  <register>
+    <name>wdogcount</name>
+    <description>Counter Register</description>
+    <addressOffset>0x8</addressOffset>
+  </register>
+  <register>
+    <name>wdogs</name>
+    <description>Scaled value of Counter</description>
+    <addressOffset>0x10</addressOffset>
+  </register>
+  <register>
+    <name>wdogfeed</name>
+    <description>Feed register</description>
+    <addressOffset>0x18</addressOffset>
+  </register>
+  <register>
+    <name>wdogkey</name>
+    <description>Key Register</description>
+    <addressOffset>0x1C</addressOffset>
+  </register>
+  <register>
+    <name>wdogcmp0</name>
+    <description>Comparator 0</description>
+    <addressOffset>0x20</addressOffset>
+  </register>
+  <register>
+    <name>rtccfg</name>
+    <description>rtc Configuration</description>
+    <addressOffset>0x40</addressOffset>
+    <fields>
+      <field>
+        <name>rtcscale</name>
+        <description>Counter scale value.</description>
+        <bitRange>[3:0]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>rtcenalways</name>
+        <description>Enable Always - run continuously</description>
+        <bitRange>[12:12]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>rtcip0</name>
+        <description>Interrupt 0 Pending</description>
+        <bitRange>[28:28]</bitRange>
+        <access>read-write</access>
+      </field>
+    </fields>
+  </register>
+  <register>
+    <name>rtccountlo</name>
+    <description>Low bits of Counter</description>
+    <addressOffset>0x48</addressOffset>
+  </register>
+  <register>
+    <name>rtccounthi</name>
+    <description>High bits of Counter</description>
+    <addressOffset>0x4C</addressOffset>
+  </register>
+  <register>
+    <name>rtcs</name>
+    <description>Scaled value of Counter</description>
+    <addressOffset>0x50</addressOffset>
+  </register>
+  <register>
+    <name>rtccmp0</name>
+    <description>Comparator 0</description>
+    <addressOffset>0x60</addressOffset>
+  </register>
+  <register>
+    <name>pmuwakeupi0</name>
+    <description>Wakeup program instruction 0</description>
+    <addressOffset>0x100</addressOffset>
+  </register>
+  <register>
+    <name>pmuwakeupi1</name>
+    <description>Wakeup program instruction 1</description>
+    <addressOffset>0x104</addressOffset>
+  </register>
+  <register>
+    <name>pmuwakeupi2</name>
+    <description>Wakeup program instruction 2</description>
+    <addressOffset>0x108</addressOffset>
+  </register>
+  <register>
+    <name>pmuwakeupi3</name>
+    <description>Wakeup program instruction 3</description>
+    <addressOffset>0x10C</addressOffset>
+  </register>
+  <register>
+    <name>pmuwakeupi4</name>
+    <description>Wakeup program instruction 4</description>
+    <addressOffset>0x110</addressOffset>
+  </register>
+  <register>
+    <name>pmuwakeupi5</name>
+    <description>Wakeup program instruction 5</description>
+    <addressOffset>0x114</addressOffset>
+  </register>
+  <register>
+    <name>pmuwakeupi6</name>
+    <description>Wakeup program instruction 6</description>
+    <addressOffset>0x118</addressOffset>
+  </register>
+  <register>
+    <name>pmuwakeupi7</name>
+    <description>Wakeup program instruction 7</description>
+    <addressOffset>0x11C</addressOffset>
+  </register>
+  <register>
+    <name>pmusleepi0</name>
+    <description>Sleep program instruction 0</description>
+    <addressOffset>0x120</addressOffset>
+  </register>
+  <register>
+    <name>pmusleepi1</name>
+    <description>Sleep program instruction 1</description>
+    <addressOffset>0x124</addressOffset>
+  </register>
+  <register>
+    <name>pmusleepi2</name>
+    <description>Sleep program instruction 2</description>
+    <addressOffset>0x128</addressOffset>
+  </register>
+  <register>
+    <name>pmusleepi3</name>
+    <description>Sleep program instruction 3</description>
+    <addressOffset>0x12C</addressOffset>
+  </register>
+  <register>
+    <name>pmusleepi4</name>
+    <description>Sleep program instruction 4</description>
+    <addressOffset>0x130</addressOffset>
+  </register>
+  <register>
+    <name>pmusleepi5</name>
+    <description>Sleep program instruction 5</description>
+    <addressOffset>0x134</addressOffset>
+  </register>
+  <register>
+    <name>pmusleepi6</name>
+    <description>Sleep program instruction 6</description>
+    <addressOffset>0x138</addressOffset>
+  </register>
+  <register>
+    <name>pmusleepi7</name>
+    <description>Sleep program instruction 7</description>
+    <addressOffset>0x13C</addressOffset>
+  </register>
+  <register>
+    <name>pmuie</name>
+    <description>PMU Interrupt Enables</description>
+    <addressOffset>0x140</addressOffset>
+  </register>
+  <register>
+    <name>pmucause</name>
+    <description>PMU Wakeup Cause</description>
+    <addressOffset>0x144</addressOffset>
+  </register>
+  <register>
+    <name>pmusleep</name>
+    <description>Initiate PMU Sleep Sequence</description>
+    <addressOffset>0x148</addressOffset>
+  </register>
+  <register>
+    <name>pmukey</name>
+    <description>PMU Key. Reads as 1 when PMU is unlocked</description>
+    <addressOffset>0x14C</addressOffset>
+  </register>
+  <register>
+    <name>aoncfg</name>
+    <description>AON Block Configuration Information</description>
+    <addressOffset>0x300</addressOffset>
+    <fields>
+      <field>
+        <name>has_bandgap</name>
+        <description>Bandgap feature is present</description>
+        <bitRange>[0:0]</bitRange>
+        <access>read-only</access>
+      </field>
+      <field>
+        <name>has_bod</name>
+        <description>Brownout detector feature is present</description>
+        <bitRange>[1:1]</bitRange>
+        <access>read-only</access>
+      </field>
+      <field>
+        <name>has_lfrosc</name>
+        <description>Low Frequency Ring Oscillator feature is present</description>
+        <bitRange>[2:2]</bitRange>
+        <access>read-only</access>
+      </field>
+      <field>
+        <name>has_lfrcosc</name>
+        <description>Low Frequency RC Oscillator feature is present</description>
+        <bitRange>[3:3]</bitRange>
+        <access>read-only</access>
+      </field>
+      <field>
+        <name>has_lfxosc</name>
+        <description>Low Frequency Crystal Oscillator feature is present</description>
+        <bitRange>[4:4]</bitRange>
+        <access>read-only</access>
+      </field>
+      <field>
+        <name>has_por</name>
+        <description>Power-On-Reset feature is present</description>
+        <bitRange>[5:5]</bitRange>
+        <access>read-only</access>
+      </field>
+      <field>
+        <name>has_ldo</name>
+        <description>Low Dropout Regulator feature is present</description>
+        <bitRange>[6:6]</bitRange>
+        <access>read-only</access>
+      </field>
+    </fields>
+  </register>
+  <register>
+    <name>lfrosccfg</name>
+    <description>Ring Oscillator Configuration and Status</description>
+    <addressOffset>0x70</addressOffset>
+    <fields>
+      <field>
+        <name>lfroscdiv</name>
+        <description>Ring Oscillator Divider Register</description>
+        <bitRange>[5:0]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>lfrosctrim</name>
+        <description>Ring Oscillator Trim Register</description>
+        <bitRange>[20:16]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>lfroscen</name>
+        <description>Ring Oscillator Enable</description>
+        <bitRange>[30:30]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>lfroscrdy</name>
+        <description>Ring Oscillator Ready</description>
+        <bitRange>[31:31]</bitRange>
+        <access>read-only</access>
+      </field>
+    </fields>
+  </register>
+  <register>
+    <name>lfclkmux</name>
+    <description>Low-Frequency Clock Mux Control and Status</description>
+    <addressOffset>0x7C</addressOffset>
+    <fields>
+      <field>
+        <name>lfextclk_sel</name>
+        <description>Low Frequency Clock Source Selector</description>
+        <bitRange>[0:0]</bitRange>
+        <access>read-write</access>
+        <enumeratedValues>
+          <enumeratedValue>
+            <name>internal</name>
+            <description>Use internal LF clock source</description>
+            <value>0</value>
+          </enumeratedValue>
+          <enumeratedValue>
+            <name>external</name>
+            <description>Use external LF clock source</description>
+            <value>1</value>
+          </enumeratedValue>
+        </enumeratedValues>
+      </field>
+      <field>
+        <name>lfextclk_mux_status</name>
+        <description>Setting of the aon_lfclksel pin</description>
+        <bitRange>[31:31]</bitRange>
+        <access>read-only</access>
+        <enumeratedValues>
+          <enumeratedValue>
+            <name>external</name>
+            <description>Use external LF clock source</description>
+            <value>0</value>
+          </enumeratedValue>
+          <enumeratedValue>
+            <name>sw</name>
+            <description>Use clock source selected by lfextclk_sel</description>
+            <value>1</value>
+          </enumeratedValue>
+        </enumeratedValues>
+      </field>
+    </fields>
+  </register>
+</registers>

--- a/regmaps/sifive_rtc0_control.svd
+++ b/regmaps/sifive_rtc0_control.svd
@@ -1,0 +1,47 @@
+<registers>
+  <register>
+    <name>rtccfg</name>
+    <description>rtc Configuration</description>
+    <addressOffset>0x40</addressOffset>
+    <fields>
+      <field>
+        <name>rtcscale</name>
+        <description>Counter scale value.</description>
+        <bitRange>[3:0]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>rtcenalways</name>
+        <description>Enable Always - run continuously</description>
+        <bitRange>[12:12]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>rtcip0</name>
+        <description>Interrupt 0 Pending</description>
+        <bitRange>[28:28]</bitRange>
+        <access>read-write</access>
+      </field>
+    </fields>
+  </register>
+  <register>
+    <name>rtccountlo</name>
+    <description>Low bits of Counter</description>
+    <addressOffset>0x48</addressOffset>
+  </register>
+  <register>
+    <name>rtccounthi</name>
+    <description>High bits of Counter</description>
+    <addressOffset>0x4C</addressOffset>
+  </register>
+  <register>
+    <name>rtcs</name>
+    <description>Scaled value of Counter</description>
+    <addressOffset>0x50</addressOffset>
+  </register>
+  <register>
+    <name>rtccmp0</name>
+    <description>Comparator 0</description>
+    <addressOffset>0x60</addressOffset>
+  </register>
+</registers>

--- a/regmaps/sifive_wdog0_control.svd
+++ b/regmaps/sifive_wdog0_control.svd
@@ -1,0 +1,70 @@
+<registers>
+  <register>
+    <name>wdogcfg</name>
+    <description>wdog Configuration</description>
+    <addressOffset>0x0</addressOffset>
+    <fields>
+      <field>
+        <name>wdogscale</name>
+        <description>Counter scale value.</description>
+        <bitRange>[3:0]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogrsten</name>
+        <description>Controls whether the comparator output can set the wdogrst bit and hence cause a full reset.</description>
+        <bitRange>[8:8]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogzerocmp</name>
+        <description>Reset counter to zero after match.</description>
+        <bitRange>[9:9]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogenalways</name>
+        <description>Enable Always - run continuously</description>
+        <bitRange>[12:12]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogcoreawake</name>
+        <description>Increment the watchdog counter if the processor is not asleep</description>
+        <bitRange>[13:13]</bitRange>
+        <access>read-write</access>
+      </field>
+      <field>
+        <name>wdogip0</name>
+        <description>Interrupt 0 Pending</description>
+        <bitRange>[28:28]</bitRange>
+        <access>read-write</access>
+      </field>
+    </fields>
+  </register>
+  <register>
+    <name>wdogcount</name>
+    <description>Counter Register</description>
+    <addressOffset>0x8</addressOffset>
+  </register>
+  <register>
+    <name>wdogs</name>
+    <description>Scaled value of Counter</description>
+    <addressOffset>0x10</addressOffset>
+  </register>
+  <register>
+    <name>wdogfeed</name>
+    <description>Feed register</description>
+    <addressOffset>0x18</addressOffset>
+  </register>
+  <register>
+    <name>wdogkey</name>
+    <description>Key Register</description>
+    <addressOffset>0x1C</addressOffset>
+  </register>
+  <register>
+    <name>wdogcmp0</name>
+    <description>Comparator 0</description>
+    <addressOffset>0x20</addressOffset>
+  </register>
+</registers>


### PR DESCRIPTION
Attempting to address the failed test in https://github.com/sifive/freedom-e-sdk/pull/462 led me to regenerating the BSP and noticing the SVD is losing this section.

This change copies the AON block regmaps from `*_mem.svd` to `*_control.svd` as a backwards compatible upgrade path.