### PR TITLE
Use wake 'here' to make install path source location flexible

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -74,6 +74,9 @@ global target installSVDGenerator installPath =
     source "{here}/generate_svd.py",
     sources "{here}/regmaps" `.*\.svd` ++
     sources "{here}/scripts" `.*\.py`
-
+  def installWithStructure dir file =
+    def oneDown = simplify "{here}/.."
+    def into = "{dir}/{relative oneDown file.getPathName}"
+    installAs into file
   mkdir installPath,
-  map (installIn installPath) generatorSources
+  map (installWithStructure installPath) generatorSources


### PR DESCRIPTION
`installIn` is defined as 
```
export def installIn dir file =
  installAs "{dir}/{file.getPathName}" file
```

When used with Wit, the `getPathName` would include only the repository name, for example:
```
installIn "builddir" pathToSomeFile -> builddir/cmsis-svd-generator/somefile.sh
```
When the wake rule is used via git submodules a longer path is inserted, for example
```
installIn "builddir" pathToSomeFile -> builddir/freedom-e-sdk/software/cmsis-svd-generator/somefile.sh
```
This PR aims to resolve the inconsistency by using `here/..` to capture the repository name directly, thus preserving the paths in `builddir`