### PR TITLE
generate_svd: generalize DTS parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # cmsis-svd-generator
 Generates CMSIS-SVD xml files from DTS info and Register templates in the regmaps directory.
+
+# Generating a compatible DTS file
+
+Many DTS files are multi-level, and have both C and DSTI includes.
+
+To flatten the DTS file, one can run the C preprocessor and device tree compiler:
+
+```bash
+# run CPP to handle any C-style includes
+
+cpp -nostdinc -I include -I arch  -undef -x assembler-with-cpp /path/to/input.dts > processed.dts
+
+# run DTC to handle any DTSI includes
+
+dtc -I dts -O dts -o output.dts processed.dts
+
+# finally, run generate-svd.py
+
+./generate-svd.py -o output.svd -d output.dts
+```


### PR DESCRIPTION
Generalizes the DTS parser to not rely on the presence of the `reg-names` field to parse `reg` field in peripherals child nodes.

Instead, rely on the structure as defined by the DTS specification, i.e. the address field is first indexed at `<address-cells> - 1`, and the size field is second indexed at `<address-cells> + <size-cells> - 1`.

Search compatible list for `clic0`, `clint0`, and `plic0` strings, and modifies the `script_path` to point to the relevant regmap generator.

Adds instructions for flattening DTS files that include C and/or DTSI files.